### PR TITLE
fix broken image link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,7 @@
     <!-- HEADER -->
     <header>
       <div id="lf_header">
-        <div class="container"><a href="https://www.linuxfoundation.org/projects" target="_blank" rel="noopener"><img class="header_image" style="padding-top:1px" src="https://tungsten.io/wp-content/uploads/2018/03/logo_lf_projects_horizontal.png" width="268" height="15"/></a></div>
+        <div class="container"><a href="https://www.linuxfoundation.org/projects" target="_blank" rel="noopener"><img class="header_image" style="padding-top:1px" src="https://tungsten.io/wp-content/themes/salient-child/images/logo_lf_projects_horizontal_2018.png" width="500" height="28"/></a></div>
         </div><div id="tungsten_header" style="text-align:right;">
         <div class="container">
           <!-- #site-logo -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,7 @@
     <!-- HEADER -->
     <header>
       <div id="lf_header">
-        <div class="container"><a href="https://www.linuxfoundation.org/projects" target="_blank" rel="noopener"><img class="header_image" style="padding-top:1px" src="https://tungsten.io/wp-content/themes/salient-child/images/logo_lf_projects_horizontal_2018.png" width="500" height="28"/></a></div>
+        <div class="container"><a id="lf-header" href="https://www.linuxfoundation.org/projects" target="_blank" rel="noopener"><img class="header_image" style="padding-top:1px" src="https://tungsten.io/wp-content/themes/salient-child/images/logo_lf_projects_horizontal_2018.png" width="500" height="28"/></a></div>
         </div><div id="tungsten_header" style="text-align:right;">
         <div class="container">
           <!-- #site-logo -->


### PR DESCRIPTION
This fixes the broken image up the top of:

https://tungstenfabric.github.io/website/Tungsten-Fabric-Centos-one-line-install-on-k8s.html

However the css for `#lf-header` does not appear to get loaded.

e.g. open [this link](https://tungsten.io/start/), and adjust the width of your window. The headers change size and layout. But adjust [https://tungstenfabric.github.io/website/Tungsten-Fabric-Centos-one-line-install-on-k8s.html](this page), and the same thing doesn't happen.

I adjusted the dimensions of the `<img>` to match the original file. My understanding is that this is best practice, to prevent the browser from doing reflow adjustments. And the desired size should be specified through CSS, just like on [the other page](https://tungsten.io/start/).