### PR TITLE
Update the Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ under discussion.
 [Tungsten Fabric Detailed Architecture Document]: Tungsten-Fabric-Architecture.md
 [tungsten-dev@googlegroups.com]: https://groups.google.com/forum/#!forum/tungsten-dev
 [dev@lists.tungsten.io]: https://lists.tungsten.io/g/dev
-[Join Slack]: https://tungsten.io/slack
+[Join Slack]: https://join.slack.com/t/tungstenfabric/shared_invite/enQtMzM0MjMyMDIzMzk3LTZmY2FmY2JlZmRjN2YxMzgyOTNkNDZiNTRiYWU0NTRmNzI3N2RjMDIwY2UxZDlkODgzZDE0YzQ3MTlhNTg0N2I
 [contrail-specs]: https://github.com/Juniper/contrail-specs
 [GitHub]: http://github.com/tungstenfabric
 [git-review extension]: https://docs.openstack.org/infra/git-review/

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -79,7 +79,7 @@
                 <p class="footer_heading">Engage</p>
                 <ul class="footer-menu">
                   <li class="no-label footer-menu-item"><a href="https://github.com/tungstenfabric/" target="_blank" title="Visit Tungsten Fabric on GitHub"><span class="fab fa-2x fa-github"></span></a></li>
-                  <li class="no-label footer-menu-item"><a href="https://join.slack.com/t/tungstenfabric/shared_invite/enQtMzM0MjMyMDIzMzk3LTZjM2JmMWZlOGMyM2RlZDAxM2RiYjE0YWZlMTAyYWIzYmNmYmY4MTc5MzIzNjk5YWY2N2JmNzIzNzJlZmMzMzU" target="_blank" title="Visit Tungsten Fabric on Slack"><span class="fab fa-2x fa-slack"></span></a></li>
+                  <li class="no-label footer-menu-item"><a href="https://join.slack.com/t/tungstenfabric/shared_invite/enQtMzM0MjMyMDIzMzk3LTZmY2FmY2JlZmRjN2YxMzgyOTNkNDZiNTRiYWU0NTRmNzI3N2RjMDIwY2UxZDlkODgzZDE0YzQ3MTlhNTg0N2I" target="_blank" title="Visit Tungsten Fabric on Slack"><span class="fab fa-2x fa-slack"></span></a></li>
                   <li class="no-label footer-menu-item"><a href="https://twitter.com/tungstenfabric" target="_blank" title="Visit Tungsten Fabric on Twitter"><span class="fab fa-2x fa-twitter"></span></a></li>
                   <li class="no-label footer-menu-item"><a href="https://www.facebook.com/tungstenfabric/" target="_blank" title="Visit Tungsten Fabric on Facebook"><span class="fab fa-2x fa-facebook"></span></a></li>
                   <li class="no-label footer-menu-item"><a href="https://www.linkedin.com/groups/6517760" target="_blank" title="Visit Tungsten Fabric on LinkedIn"><span class="fab fa-2x fa-linkedin"></span></a></li>


### PR DESCRIPTION
The prior link had an expiration date set. This one does not.

Closes #41 