### PR TITLE
Changed manifest to container builder method on getting started Centos and Ubuntu pages

### DIFF
--- a/Tungsten-Fabric-Centos-one-line-install-on-k8s.md
+++ b/Tungsten-Fabric-Centos-one-line-install-on-k8s.md
@@ -24,7 +24,7 @@ This wiki will describe the most simplest of all: **A single yaml based install*
 
 {% raw %}
 ```
-K8S_MASTER_IP=x.x.x.x; CONTRAIL_REPO="docker.io\/opencontrailnightly"; CONTRAIL_RELEASE="latest"; mkdir -pm 777 /var/lib/contrail/kafka-logs; curl https://raw.githubusercontent.com/Juniper/contrail-kubernetes-docs/master/install/kubernetes/templates/contrail-single-step-cni-install-centos.yaml | sed "s/{{ K8S_MASTER_IP }}/$K8S_MASTER_IP/g; s/{{ CONTRAIL_REPO }}/$CONTRAIL_REPO/g; s/{{ CONTRAIL_RELEASE }}/$CONTRAIL_RELEASE/g" | kubectl apply -f -
+export MASTER_IP="x.x.x.x" ; mkdir /root/tf ; git clone https://github.com/Juniper/contrail-container-builder /root/tf/contrail-container-builder ; mv /root/tf/contrail-container-builder/kubernetes/sample_config_files/common.env.kubernetes /root/tf/contrail-container-builder/common.env ; sed -i "s/10.84.13.54/$MASTER_IP/" /root/tf/contrail-container-builder/common.env ; /root/tf/contrail-container-builder/kubernetes/manifests/./resolve-manifest.sh /root/tf/contrail-container-builder/kubernetes/manifests/contrail-standalone-kubernetes.yaml > /root/tf/tf.yml ; /root/tf/contrail-container-builder/kubernetes/manifests/./set-node-labels.sh ; kubectl apply -f /root/tf/tf.yml
 ```
 {% endraw %}
 

--- a/Tungsten-Fabric-Ubuntu-one-line-install-on-k8s.md
+++ b/Tungsten-Fabric-Ubuntu-one-line-install-on-k8s.md
@@ -18,7 +18,7 @@ This wiki will describe the most simplest of all: **A single yaml based install*
 
 {% raw %}
 ```
-K8S_MASTER_IP=x.x.x.x; CONTRAIL_REPO="docker.io\/opencontrailnightly"; CONTRAIL_RELEASE="latest"; mkdir -pm 777 /var/lib/contrail/kafka-logs; curl https://raw.githubusercontent.com/Juniper/contrail-kubernetes-docs/master/install/kubernetes/templates/contrail-single-step-cni-install-ubuntu.yaml | sed "s/{{ K8S_MASTER_IP }}/$K8S_MASTER_IP/g; s/{{ CONTRAIL_REPO }}/$CONTRAIL_REPO/g; s/{{ CONTRAIL_RELEASE }}/$CONTRAIL_RELEASE/g" | kubectl apply -f -
+export MASTER_IP="x.x.x.x" ; mkdir /root/tf ; git clone https://github.com/Juniper/contrail-container-builder /root/tf/contrail-container-builder ; mv /root/tf/contrail-container-builder/kubernetes/sample_config_files/common.env.kubernetes /root/tf/contrail-container-builder/common.env ; sed -i "s/10.84.13.54/$MASTER_IP/" /root/tf/contrail-container-builder/common.env ; /root/tf/contrail-container-builder/kubernetes/manifests/./resolve-manifest.sh /root/tf/contrail-container-builder/kubernetes/manifests/contrail-standalone-kubernetes.yaml > /root/tf/tf.yml ; sed -i "s/kernel-init/kernel-build-init/" /root/tf/tf.yml ; /root/tf/contrail-container-builder/kubernetes/manifests/./set-node-labels.sh ; kubectl apply -f /root/tf/tf.yml
 ```
 {% endraw %}
 


### PR DESCRIPTION
Updated the getting started one-liner installs to use the official container builder method.